### PR TITLE
feature/add-node-index-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,7 +1251,7 @@ ethereum_metrics_exporter_enabled: true
 
 ## Custom labels for Docker and Kubernetes
 
-There are 4 custom labels that can be used to identify the nodes in the network. These labels are used to identify the nodes in the network and can be used to run chaos tests on specific nodes. An example for these labels are as follows:
+There are 6 custom labels that can be used to identify the nodes in the network. These labels are used to identify the nodes in the network and can be used to run chaos tests on specific nodes. An example for these labels are as follows:
 
 Execution Layer (EL) nodes:
 
@@ -1261,6 +1261,7 @@ Execution Layer (EL) nodes:
   "kurtosistech.com.custom/ethereum-package.client-language:": "go",
   "kurtosistech.com.custom/ethereum-package.client-type": "execution",
   "kurtosistech.com.custom/ethereum-package.connected-client": "lighthouse",
+  "kurtosistech.com.custom/ethereum-package.node-index": "1",
 ```
 
 Consensus Layer (CL) nodes - Beacon:
@@ -1271,6 +1272,7 @@ Consensus Layer (CL) nodes - Beacon:
   "kurtosistech.com.custom/ethereum-package.client-language:": "rust",
   "kurtosistech.com.custom/ethereum-package.client-type": "beacon",
   "kurtosistech.com.custom/ethereum-package.connected-client": "geth",
+  "kurtosistech.com.custom/ethereum-package.node-index": "1",
 ```
 
 Consensus Layer (CL) nodes - Validator:
@@ -1281,6 +1283,7 @@ Consensus Layer (CL) nodes - Validator:
   "kurtosistech.com.custom/ethereum-package.client-language:": "rust",
   "kurtosistech.com.custom/ethereum-package.client-type": "validator",
   "kurtosistech.com.custom/ethereum-package.connected-client": "geth",
+  "kurtosistech.com.custom/ethereum-package.node-index": "1",
 ```
 
 * `ethereum-package.client` describes which client is running on the node.
@@ -1288,6 +1291,7 @@ Consensus Layer (CL) nodes - Validator:
 * `ethereum-package.client-type` describes the type of client that is running on the node (`execution`,`beacon` or `validator`).
 * `ethereum-package.connected-client` describes the CL/EL client that is connected to the EL/CL client.
 * `ethereum-package.client-language` describes the implementation language of the running service.
+* `ethereum-package.node-index` describes the index of the node (participant) that the service belongs to.
 
 ## Proposer Builder Separation (PBS) emulation
 

--- a/src/cl/grandine/grandine_launcher.star
+++ b/src/cl/grandine/grandine_launcher.star
@@ -365,7 +365,8 @@ def get_beacon_config(
             client_type=constants.CLIENT_TYPES.cl,
             image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=el_context.client_name,
-            extra_labels=participant.cl_extra_labels,
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -354,7 +354,8 @@ def get_beacon_config(
             client_type=constants.CLIENT_TYPES.cl,
             image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=el_context.client_name,
-            extra_labels=participant.cl_extra_labels,
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/cl/lodestar/lodestar_launcher.star
+++ b/src/cl/lodestar/lodestar_launcher.star
@@ -341,7 +341,8 @@ def get_beacon_config(
             client_type=constants.CLIENT_TYPES.cl,
             image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=el_context.client_name,
-            extra_labels=participant.cl_extra_labels,
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/cl/nimbus/nimbus_launcher.star
+++ b/src/cl/nimbus/nimbus_launcher.star
@@ -371,7 +371,8 @@ def get_beacon_config(
             client_type=constants.CLIENT_TYPES.cl,
             image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=el_context.client_name,
-            extra_labels=participant.cl_extra_labels,
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -348,7 +348,8 @@ def get_beacon_config(
             client_type=constants.CLIENT_TYPES.cl,
             image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=el_context.client_name,
-            extra_labels=participant.cl_extra_labels,
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -384,7 +384,8 @@ def get_beacon_config(
             client_type=constants.CLIENT_TYPES.cl,
             image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=el_context.client_name,
-            extra_labels=participant.cl_extra_labels,
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -262,7 +262,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "user": User(uid=0, gid=0),

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -266,7 +266,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/el/ethereumjs/ethereumjs_launcher.star
+++ b/src/el/ethereumjs/ethereumjs_launcher.star
@@ -252,7 +252,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -323,7 +323,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -244,7 +244,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/el/nimbus-eth1/nimbus_launcher.star
+++ b/src/el/nimbus-eth1/nimbus_launcher.star
@@ -235,7 +235,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -306,7 +306,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.el,
             image=participant.el_image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_client_name,
-            extra_labels=participant.el_extra_labels,
+            extra_labels=participant.el_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
+++ b/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
@@ -78,6 +78,7 @@ def launch(
         el_cl_genesis_data,
         global_node_selectors,
         public_ports,
+        index,
     )
 
     mev_boost_service = plan.add_service(service_name, config)
@@ -95,6 +96,7 @@ def get_config(
     el_cl_genesis_data,
     node_selectors,
     public_ports,
+    participant_index,
 ):
     return ServiceConfig(
         image=image,
@@ -114,6 +116,7 @@ def get_config(
         min_memory=MIN_MEMORY,
         max_memory=MAX_MEMORY,
         node_selectors=node_selectors,
+        labels={constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
     )
 
 

--- a/src/mev/flashbots/mev_boost/mev_boost_launcher.star
+++ b/src/mev/flashbots/mev_boost/mev_boost_launcher.star
@@ -54,6 +54,7 @@ def launch(
         participant,
         seconds_per_slot,
         public_ports,
+        index,
     )
 
     mev_boost_service = plan.add_service(service_name, config)
@@ -74,6 +75,7 @@ def get_config(
     participant,
     seconds_per_slot,
     public_ports,
+    participant_index,
 ):
     command = mev_boost_args
 
@@ -99,6 +101,14 @@ def get_config(
         min_memory=MIN_MEMORY,
         max_memory=MAX_MEMORY,
         node_selectors=node_selectors,
+        labels=shared_utils.label_maker(
+            client="mev-boost",
+            client_type="mev",
+            image=mev_boost_image[-constants.MAX_LABEL_LENGTH :],
+            connected_client="{0}-{1}".format(participant.cl_type, participant.el_type),
+            extra_labels={constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
+            supernode=participant.supernode,
+        ),
     )
 
 

--- a/src/mev/mev-rs/mev_boost/mev_boost_launcher.star
+++ b/src/mev/mev-rs/mev_boost/mev_boost_launcher.star
@@ -82,6 +82,7 @@ def launch(
         el_cl_genesis_data,
         global_node_selectors,
         public_ports,
+        index,
     )
 
     mev_boost_service = plan.add_service(service_name, config)
@@ -99,6 +100,7 @@ def get_config(
     el_cl_genesis_data,
     node_selectors,
     public_ports,
+    participant_index,
 ):
     return ServiceConfig(
         image=image,
@@ -117,6 +119,7 @@ def get_config(
         min_memory=MIN_MEMORY,
         max_memory=MAX_MEMORY,
         node_selectors=node_selectors,
+        labels={constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
     )
 
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -332,6 +332,9 @@ CLIENT_LANGUAGES = {
 # Label key constant for client language
 CLIENT_LANGUAGE_LABEL_KEY = "ethereum-package.client-language"
 
+# Label key constant for node index
+NODE_INDEX_LABEL_KEY = "ethereum-package.node-index"
+
 VOLUME_SIZE["mainnet-shadowfork"] = VOLUME_SIZE["mainnet"]
 VOLUME_SIZE["sepolia-shadowfork"] = VOLUME_SIZE["sepolia"]
 VOLUME_SIZE["holesky-shadowfork"] = VOLUME_SIZE["holesky"]

--- a/src/remote_signer/remote_signer_launcher.star
+++ b/src/remote_signer/remote_signer_launcher.star
@@ -164,7 +164,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.remote_signer,
             image=image,
             connected_client=vc_type,
-            extra_labels=participant.remote_signer_extra_labels,
+            extra_labels=participant.remote_signer_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(remote_signer_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/vc/lighthouse.star
+++ b/src/vc/lighthouse.star
@@ -126,7 +126,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.validator,
             image=image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_context.client_name,
-            extra_labels=participant.vc_extra_labels,
+            extra_labels=participant.vc_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(vc_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/vc/lodestar.star
+++ b/src/vc/lodestar.star
@@ -140,7 +140,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.validator,
             image=image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_context.client_name,
-            extra_labels=participant.vc_extra_labels,
+            extra_labels=participant.vc_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(vc_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/vc/nimbus.star
+++ b/src/vc/nimbus.star
@@ -113,7 +113,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.validator,
             image=image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_context.client_name,
-            extra_labels=participant.vc_extra_labels,
+            extra_labels=participant.vc_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(vc_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -129,7 +129,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.validator,
             image=image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_context.client_name,
-            extra_labels=participant.vc_extra_labels,
+            extra_labels=participant.vc_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(vc_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/vc/teku.star
+++ b/src/vc/teku.star
@@ -131,7 +131,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.validator,
             image=image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_context.client_name,
-            extra_labels=participant.vc_extra_labels,
+            extra_labels=participant.vc_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(vc_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,

--- a/src/vc/vero.star
+++ b/src/vc/vero.star
@@ -77,7 +77,8 @@ def get_config(
             client_type=constants.CLIENT_TYPES.validator,
             image=image[-constants.MAX_LABEL_LENGTH :],
             connected_client=cl_context.client_name,
-            extra_labels=participant.vc_extra_labels,
+            extra_labels=participant.vc_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(vc_index + 1)},
             supernode=participant.supernode,
         ),
         "tolerations": tolerations,


### PR DESCRIPTION
This PR adds a new label to the services that run for each node which is meant to be a quality of life improvement. The new label node-index which allows you to query all services for a node with a simple selector instead of having to parse the all the service names and have different regexes based on the service type.